### PR TITLE
Update crds for syncInterval

### DIFF
--- a/dockhand-secrets-operator-crd/Chart.yaml
+++ b/dockhand-secrets-operator-crd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: dockhand-secrets-operator-crd
 description: A Helm chart to install the dockhand-secrets-operator CRDs
-version: 1.0.0
+version: 1.1.0

--- a/dockhand-secrets-operator-crd/templates/crd/profile-crd.yaml
+++ b/dockhand-secrets-operator-crd/templates/crd/profile-crd.yaml
@@ -66,6 +66,7 @@ spec:
                 cacheTTL:
                   type: string
                   default: 60s
+                  format: duration
                   description: |-
                     Duration to cache secret responses
                 tenant:

--- a/dockhand-secrets-operator-crd/templates/crd/secret-crd.yaml
+++ b/dockhand-secrets-operator-crd/templates/crd/secret-crd.yaml
@@ -43,6 +43,18 @@ spec:
                   type: string
                   description: |-
                     Namespace of profile (optional) defaults to same namespace
+            syncInterval:
+              type: string
+              default: 0s
+              format: duration
+              description: |-
+                Specifies the time interval for polling the secrets backend for changes.
+                The default value of 0 indicates that no polling will occur and is the
+                default behavior prior to 1.1.0 release, in this case the operator will only query
+                the backend when a field in the Dockhand Secret CRD has been modified.
+                Valid time units are ns, µs (or us), ms, s, m, h, but must exceed 5s (when not 0).
+                Also note that the operator will not poll the backend more frequently than
+                the cacheTTL of the profile referenced by the Secret
             secretSpec:
               type: object
               description: |-
@@ -75,7 +87,7 @@ spec:
             status:
               type: object
               description: |-
-                Provides basic status for a DockhandSecret
+                Provides basic status for a Dockhand Secret
               properties:
                 state:
                   type: string
@@ -89,6 +101,11 @@ spec:
                   type: string
                   description: |-
                     The managed secret resource version last observed by the controller
+                syncTimestamp:
+                  type: string
+                  format: datetime
+                  description: |-
+                    Last time the secret was synced from the backend
             data:
               type: object
               description: |-


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>

Adds `syncInterval` to the Dockhand `Secret` CRD